### PR TITLE
fix: add missing openai_organization field to Settings class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "donkit-ragops-ce"
-version = "0.3.12"
+version = "0.3.13"
 description = "Community Edition CLI agent for building RAG pipelines"
 authors = ["Donkit AI <opensource@donkit.ai>"]
 license = "MIT"

--- a/src/ragops_agent_ce/__init__.py
+++ b/src/ragops_agent_ce/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.3.1"
+__version__ = "0.3.13"

--- a/src/ragops_agent_ce/config.py
+++ b/src/ragops_agent_ce/config.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     # API keys and endpoints
     openai_base_url: str = Field(default="https://api.openai.com/v1")
     openai_api_key: str | None = Field(default=None)
+    openai_organization: str | None = Field(default=None)
     # Azure OpenAI
     azure_openai_api_key: str | None = Field(default=None)
     azure_openai_endpoint: str | None = Field(default=None)


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'Settings' object has no attribute 'openai_organization'` that occurred when initializing OpenAI provider.

## Changes

- Added `openai_organization: str | None` field to `Settings` class in `config.py` (line 22)
- This field was referenced in `provider_factory.py` (line 75) but was missing from the Settings model
- Bumped version from `0.3.12` to `0.3.13` in `pyproject.toml` and `__init__.py`

## Problem

When trying to connect OpenAI provider, the code attempted to access `cfg.openai_organization` attribute which didn't exist in the Settings class, causing an `AttributeError`.

## Solution

Added the missing optional field `openai_organization` to the Settings class (one line addition), allowing it to be set via environment variable `RAGOPS_OPENAI_ORGANIZATION` or remain `None` if not provided.

## Testing

- [x] Code follows existing patterns
- [x] No linter errors
- [x] Field is optional (can be None)
- [x] Field matches the pattern of other optional OpenAI settings

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Files Changed

- `src/ragops_agent_ce/config.py` - Added one line: `openai_organization: str | None = Field(default=None)`
- `pyproject.toml` - Version bump to 0.3.13
- `src/ragops_agent_ce/__init__.py` - Version bump to 0.3.13